### PR TITLE
refactor: 未使用のHttpClientライブラリ削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Change: 依存ライブラリアップデート
 - BREAK: 互換性確認テスト以外のJavaコードをKotlinに移行
 - Change(runtime): Atomicクラスをatomicfuに置き換え
+- BREAK: 未使用のHttpClientライブラリ削除 (Commons Codecも16進数文字列変換のみの使用のため削除)
 
 3.1.0 (released 13 December 2022)
 ------------------

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,8 +24,6 @@ apache-thrift = "0.21.0"
 
 clikt = "5.0.3"
 
-commons-codec = "1.18.0"
-
 dokka = "2.0.0"
 
 gradle-plugin-publish = "1.3.1"
@@ -33,8 +31,6 @@ gradle-plugin-publish = "1.3.1"
 guava = "33.4.0-jre"
 
 hamcrest = "3.0"
-
-httpclient = "4.5.14"
 
 java-poet = "1.13.0"
 
@@ -70,13 +66,9 @@ apache-thrift = { group = "org.apache.thrift", name = "libthrift", version.ref =
 
 clikt = { group = "com.github.ajalt.clikt", name = "clikt", version.ref = "clikt" }
 
-commons-codec = { group = "commons-codec", name = "commons-codec", version.ref = "commons-codec" }
-
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 
 hamcrest = { group = "org.hamcrest", name = "hamcrest", version.ref = "hamcrest" }
-
-httpclient = { group = "org.apache.httpcomponents", name = "httpclient", version.ref = "httpclient" }
 
 java-poet = { group = "com.squareup", name = "javapoet", version.ref = "java-poet" }
 

--- a/thrifty-test-server/build.gradle
+++ b/thrifty-test-server/build.gradle
@@ -29,8 +29,6 @@ plugins {
 dependencies {
     api libs.junit.api
     implementation libs.apache.thrift
-    implementation libs.commons.codec
-    implementation libs.httpclient
     implementation libs.slf4j.api
     implementation libs.tomcat.embed.core
 }

--- a/thrifty-test-server/src/main/java/com/microsoft/thrifty/testing/TestServerInterface.java
+++ b/thrifty-test-server/src/main/java/com/microsoft/thrifty/testing/TestServerInterface.java
@@ -2,6 +2,7 @@
  * Thrifty
  *
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) GAHOJIN, Inc.
  *
  * All rights reserved.
  *
@@ -19,8 +20,6 @@
  * See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
  */
 package com.microsoft.thrifty.testing;
-
-import com.microsoft.thrifty.test.gen.ThriftTest;
 
 public interface TestServerInterface {
     void run(ServerProtocol protocol, ServerTransport transport);

--- a/thrifty-test-server/src/main/java/com/microsoft/thrifty/testing/TestServlet.java
+++ b/thrifty-test-server/src/main/java/com/microsoft/thrifty/testing/TestServlet.java
@@ -2,6 +2,7 @@
  * Thrifty
  *
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) GAHOJIN, Inc.
  *
  * All rights reserved.
  *
@@ -44,7 +45,6 @@ import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.server.TExtensibleServlet;
 
-@SuppressWarnings("serial")
 public class TestServlet extends TExtensibleServlet {
     private final TProtocolFactory protocolFactory;
 
@@ -62,7 +62,6 @@ public class TestServlet extends TExtensibleServlet {
         return protocolFactory;
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     protected TProcessor getProcessor() {
         ThriftTestHandler handler = new ThriftTestHandler(System.out);

--- a/thrifty-test-server/src/main/java/com/microsoft/thrifty/testing/ThriftTestHandler.java
+++ b/thrifty-test-server/src/main/java/com/microsoft/thrifty/testing/ThriftTestHandler.java
@@ -2,6 +2,7 @@
  * Thrifty
  *
  * Copyright (c) Microsoft Corporation
+ * Copyright (c) GAHOJIN, Inc.
  *
  * All rights reserved.
  *
@@ -30,8 +31,8 @@ import com.microsoft.thrifty.test.gen.Xception;
 import com.microsoft.thrifty.test.gen.Xception2;
 import com.microsoft.thrifty.test.gen.Xtruct;
 import com.microsoft.thrifty.test.gen.Xtruct2;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.thrift.TException;
+import org.apache.tomcat.util.buf.HexUtils;
 
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
@@ -98,7 +99,7 @@ public class ThriftTestHandler implements ThriftTest.Iface {
         byte[] data = new byte[count];
         thing.get(data);
 
-        out.printf("testBinary(\"%s\")\n", Hex.encodeHexString(data));
+        out.printf("testBinary(\"%s\")\n", HexUtils.toHexString(data));
 
         return ByteBuffer.wrap(data);
     }


### PR DESCRIPTION
Commons Codecも16進数文字列変換のみの使用のため削除