### PR TITLE
fix: pluginテストのbuild.gradleに定義しているkotlin標準ライブラリをstdlib-jdk8からstdlibに変更

### DIFF
--- a/thrifty-gradle-plugin/src/test/projects/java_project_kotlin_thrifts/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/java_project_kotlin_thrifts/build.gradle
@@ -5,6 +5,6 @@ plugins {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    api "org.jetbrains.kotlin:kotlin-stdlib"
     api msft.thrifty.runtime
 }

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_integration_project/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_integration_project/build.gradle
@@ -5,6 +5,6 @@ plugins {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    api "org.jetbrains.kotlin:kotlin-stdlib"
     api msft.thrifty.runtime
 }

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_multiple_source_dirs/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_multiple_source_dirs/build.gradle
@@ -9,6 +9,6 @@ thrifty {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    api "org.jetbrains.kotlin:kotlin-stdlib"
     api msft.thrifty.runtime
 }

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_filtered_thrifts/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_filtered_thrifts/build.gradle
@@ -10,6 +10,6 @@ thrifty {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    api "org.jetbrains.kotlin:kotlin-stdlib"
     api msft.thrifty.runtime
 }

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_java_thrifts/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_java_thrifts/build.gradle
@@ -8,6 +8,6 @@ thrifty {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    api "org.jetbrains.kotlin:kotlin-stdlib"
     api msft.thrifty.runtime
 }

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_kotlin_thrifts/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_kotlin_thrifts/build.gradle
@@ -4,6 +4,6 @@ plugins {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    api "org.jetbrains.kotlin:kotlin-stdlib"
     api msft.thrifty.runtime
 }

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_with_custom_output_dir/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_with_custom_output_dir/build.gradle
@@ -9,6 +9,6 @@ thrifty {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    api "org.jetbrains.kotlin:kotlin-stdlib"
     api msft.thrifty.runtime
 }

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_project_with_include_path/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_project_with_include_path/build.gradle
@@ -8,6 +8,6 @@ thrifty {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    api "org.jetbrains.kotlin:kotlin-stdlib"
     api msft.thrifty.runtime
 }

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_type_processor/app/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_type_processor/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    api "org.jetbrains.kotlin:kotlin-stdlib"
     api msft.thrifty.runtime
 
     thriftyTypeProcessor project(':processor')

--- a/thrifty-gradle-plugin/src/test/projects/kotlin_type_processor/processor/build.gradle
+++ b/thrifty-gradle-plugin/src/test/projects/kotlin_type_processor/processor/build.gradle
@@ -3,6 +3,6 @@ plugins {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    api "org.jetbrains.kotlin:kotlin-stdlib"
     api msft.thrifty.compilerPlugins
 }


### PR DESCRIPTION
-jdk8はstdlibに統合されているため、指定する必要がない