### PR TITLE
fix: parcelizeアノテーションをkotlinx.parcelizeプラグインに対応

### DIFF
--- a/thrifty-java-codegen/src/main/kotlin/jp/co/gahojin/thrifty/gen/TypeNames.kt
+++ b/thrifty-java-codegen/src/main/kotlin/jp/co/gahojin/thrifty/gen/TypeNames.kt
@@ -105,17 +105,17 @@ internal object TypeNames {
 
     val JETBRAINS_NOT_NULL = classNameOf<org.jetbrains.annotations.NotNull>()
     val JETBRAINS_NULLABLE = classNameOf<org.jetbrains.annotations.Nullable>()
-    val ANDROIDX_NOT_NULL = ClassName.get("androidx.annotation", "NonNull")
-    val ANDROIDX_NULLABLE = ClassName.get("androidx.annotation", "Nullable")
+    val ANDROIDX_NOT_NULL: ClassName = ClassName.get("androidx.annotation", "NonNull")
+    val ANDROIDX_NULLABLE: ClassName = ClassName.get("androidx.annotation", "Nullable")
 
     val SERVICE_CALLBACK = classNameOf<ServiceMethodCallback<*>>()
     val SERVICE_CLIENT_BASE = classNameOf<AsyncClientBase>()
     val SERVICE_CLIENT_LISTENER = classNameOf<AsyncClientBase.Listener>()
     val SERVICE_METHOD_CALL = classNameOf<MethodCall<*>>()
 
-    val PARCEL = ClassName.get("android.os", "Parcel")
-    val PARCELABLE = ClassName.get("android.os", "Parcelable")
-    val PARCELABLE_CREATOR = ClassName.get("android.os", "Parcelable", "Creator")
+    val PARCEL: ClassName = ClassName.get("android.os", "Parcel")
+    val PARCELABLE: ClassName = ClassName.get("android.os", "Parcelable")
+    val PARCELABLE_CREATOR: ClassName = ClassName.get("android.os", "Parcelable", "Creator")
 
     val OBFUSCATION_UTIL = classNameOf<ObfuscationUtil>()
 

--- a/thrifty-kotlin-codegen/detekt-baseline.xml
+++ b/thrifty-kotlin-codegen/detekt-baseline.xml
@@ -4,10 +4,10 @@
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$fun generate(schema: Schema): List&lt;FileSpec></ID>
     <ID>CyclomaticComplexMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$internal fun generateAdapterFor( struct: StructType, adapterName: ClassName, adapterInterfaceName: TypeName, ): TypeSpec</ID>
-    <ID>CyclomaticComplexMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$internal fun generateDataClass(schema: Schema, struct: StructType): TypeSpec</ID>
-    <ID>CyclomaticComplexMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$internal fun generateEnumClass(enumType: EnumType): TypeSpec</ID>
     <ID>CyclomaticComplexMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$internal fun generateSealedClass(schema: Schema, struct: StructType): TypeSpec</ID>
     <ID>CyclomaticComplexMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$private fun buildCallType(schema: Schema, method: ServiceMethod): TypeSpec</ID>
+    <ID>CyclomaticComplexMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$private fun generateDataClass(schema: Schema, struct: StructType): TypeSpec</ID>
+    <ID>CyclomaticComplexMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$private fun generateEnumClass(enumType: EnumType): TypeSpec</ID>
     <ID>ForbiddenComment:KotlinCodeGenerator.kt$KotlinCodeGenerator$// TODO: This assumes that the client and server share the same belief about the default value.</ID>
     <ID>ForbiddenComment:KotlinCodeGenerator.kt$KotlinCodeGenerator.&lt;no name provided>$// TODO: Implement support for binary constants in the ANTLR grammar</ID>
     <ID>LargeClass:KotlinCodeGenerator.kt$KotlinCodeGenerator</ID>
@@ -18,10 +18,10 @@
     <ID>LongMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$internal fun generateAdapterFor( struct: StructType, adapterName: ClassName, adapterInterfaceName: TypeName, ): TypeSpec</ID>
     <ID>LongMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$internal fun generateAdapterForSealed( struct: StructType, adapterName: ClassName, adapterInterfaceName: TypeName, ): TypeSpec</ID>
     <ID>LongMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$internal fun generateCoroServiceImplementation( schema: Schema, serviceType: ServiceType, serviceInterface: TypeSpec, ): TypeSpec</ID>
-    <ID>LongMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$internal fun generateDataClass(schema: Schema, struct: StructType): TypeSpec</ID>
-    <ID>LongMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$internal fun generateEnumClass(enumType: EnumType): TypeSpec</ID>
     <ID>LongMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$internal fun generateSealedClass(schema: Schema, struct: StructType): TypeSpec</ID>
     <ID>LongMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$private fun buildCallType(schema: Schema, method: ServiceMethod): TypeSpec</ID>
+    <ID>LongMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$private fun generateDataClass(schema: Schema, struct: StructType): TypeSpec</ID>
+    <ID>LongMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$private fun generateEnumClass(enumType: EnumType): TypeSpec</ID>
     <ID>LongMethod:KotlinCodeGenerator.kt$KotlinCodeGenerator$private fun generateProcessorImplementation( schema: Schema, serviceType: ServiceType, serviceInterface: TypeSpec, ): TypeSpec</ID>
     <ID>LongMethod:KotlinCodeGeneratorTest.kt$KotlinCodeGeneratorTest$@Test fun `union generate read function`()</ID>
     <ID>LongParameterList:KotlinCodeGenerator.kt$KotlinCodeGenerator$( block: CodeBlock.Builder, name: String, type: ThriftType, scope: Int = 0, localNamePrefix: String = "", failOnUnknownEnumValues: Boolean = true, )</ID>

--- a/thrifty-kotlin-codegen/src/test/kotlin/jp/co/gahojin/thrifty/kgen/KotlinCodeGeneratorTest.kt
+++ b/thrifty-kotlin-codegen/src/test/kotlin/jp/co/gahojin/thrifty/kgen/KotlinCodeGeneratorTest.kt
@@ -356,12 +356,16 @@ class KotlinCodeGeneratorTest {
         val struct = file.members.single { it is TypeSpec && it.name == "Foo" } as TypeSpec
         val anEnum = file.members.single { it is TypeSpec && it.name == "AnEnum" } as TypeSpec
         val svc = file.members.single { it is TypeSpec && it.name == "SvcClient" } as TypeSpec
-
-        val parcelize = ClassName("kotlinx.android.parcel", "Parcelize")
+        val parcelize = ClassName("kotlinx.parcelize", "Parcelize")
+        val parcelable = ClassName("android.os", "Parcelable")
 
         struct.annotations.any { it.typeName == parcelize } shouldBe true
         anEnum.annotations.any { it.typeName == parcelize } shouldBe true
         svc.annotations.any { it.typeName == parcelize } shouldBe false
+
+        struct.superinterfaces.any { it.key == parcelable } shouldBe true
+        anEnum.superinterfaces.any { it.key == parcelable } shouldBe true
+        svc.superinterfaces.any { it.key == parcelable } shouldBe false
     }
 
     @Test


### PR DESCRIPTION
kotlin-android-extensionsは非推奨となっている