### PR TITLE
build(deps): dokka 2.1.0-Betaにアップデート

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.2.10" />
+    <option name="version" value="2.2.20" />
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 4.7.0 (unreleased)
 ------------------
+- build(deps): Bump com.squareup.okio:okio from 3.11.0 to 3.16.0
+- build(deps): Bump com.fasterxml.woodstox:woodstox-core from 7.1.0 to 7.1.1
+- build(deps): Bump junit from 5.12.2 to 5.13.4
+- build(deps): Bump org.jetbrains.kotlinx:atomicfu from 0.27.0 to 0.29.0
+- build(deps): Bump io.ktor from 3.1.2 to 3.3.0
+- build(deps): Bump assertj from 3.27.3 to 3.27.6
+- build(deps): Bump kotlin from 2.1.21 to 2.2.20
+- build(deps): Bump kotest from 5.9.1 to 6.0.3
+- build(deps): Bump tomcat from 11.0.9 to 1.0.11
+- build(deps): Bump lefthook from 1.11.13 to 1.13.4
+- build(deps): Bump thrift from 0.21.0 to 0.22.0
+- build(deps): Bump jp.co.gahojin.refreshVersions from 0.1.4 to 0.4.0
+- build(deps): Bump com.vanniktech.maven.publish from 0.32.0 to 0.34.0
+- build(deps): Bump com.gradleup.shadow from 8.3.6 to 9.2.2
+- build(deps): Bump org.jetbrains.kotlinx.kover from 0.9.1 to 0.9.2
+- build(deps): Bump dokka from 2.0.0 to 2.1.0-Beta
+- build(deps): Bump npm-check-updates from 18.0.1 to 18.3.0
+- build(deps): Bump commitlint from 19.8.1 to 20.0.0
+- build(deps): Bump actions/checkout from 4.2.2 to 5.0.0
+- build(deps): Bump actions/setup-java from 4.7.1 to 5.0.0
+- build(deps): Bump gradle/actions from 4.4.0 to 4.4.3
+- Update Gradle Wrapper from 8.14.1 to 9.1.0
 
 4.6.3 (released 26 May 2025)
 ------------------

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,14 +47,3 @@ subprojects {
         jvmTarget = "21"
     }
 }
-
-// FIXME Dokkaにより、脆弱な依存関係が取り込まれている
-// https://github.com/Kotlin/dokka/issues/3194
-allprojects {
-    configurations.all {
-        resolutionStrategy {
-            force(libs.fastxml.woodstox)
-        }
-    }
-}
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,9 +32,5 @@ org.gradle.parallel=true
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.ignoreDisabledTargets=true
 
-# Dokka
-org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
-org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
-
 # Detekt
 detekt.use.worker.api=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,9 +12,7 @@ clikt = "5.0.3"
 
 detekt = "1.23.8"
 
-dokka = "2.0.0"
-
-fastxml-woodstox = "7.1.1"
+dokka = "2.1.0-Beta"
 
 gradle-plugin-publish = "2.0.0"
 
@@ -57,8 +55,6 @@ apache-thrift = { group = "org.apache.thrift", name = "libthrift", version.ref =
 assertj = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 
 clikt = { group = "com.github.ajalt.clikt", name = "clikt", version.ref = "clikt" }
-
-fastxml-woodstox = { group = "com.fasterxml.woodstox", name = "woodstox-core", version.ref = "fastxml-woodstox" }
 
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id("jp.co.gahojin.refreshVersions") version "0.3.0"
+    id("jp.co.gahojin.refreshVersions") version "0.4.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
- dokka v2設定がデフォルトになったため、pluginModeの設定削除
- dokkaがjackson脆弱性対応したため、バージョン固定設定削除